### PR TITLE
Expect header causes problems on AWS. Found a better way to disable it.

### DIFF
--- a/lib/hyperion/headers.rb
+++ b/lib/hyperion/headers.rb
@@ -8,9 +8,9 @@ class Hyperion
       headers = {}
       rd = route.response_descriptor
       pd = route.payload_descriptor
-      headers['Expect'] = 'x' # this overrides default libcurl behavior.
+      headers['Expect'] = nil # this overrides default libcurl behavior.
                               # see http://devblog.songkick.com/2012/11/27/a-second-here-a-second-there/
-                              # the value has to be non-empty or else it is ignored
+                              # and http://stackoverflow.com/questions/17383089/libcurl-delays-for-1-second-before-uploading-data-command-line-curl-does-not
       if rd
         headers['Accept'] = "application/vnd.#{Hyperion.config.vendor_string}.#{short_mimetype(rd)}"
       end

--- a/spec/lib/hyperion_spec.rb
+++ b/spec/lib/hyperion_spec.rb
@@ -19,7 +19,7 @@ describe Hyperion do
           'Accept' => "application/vnd.indigobio-ascent.#{rd.type}-v#{rd.version}+#{rd.format}",
           'Content-Type' => 'application/x-protobuf',
           'From' => 'dev@indigobio.com',
-          'Expect' => 'x'
+          'Expect' => nil
       }
 
       expect(Hyperion::Typho).to receive(:request).
@@ -43,7 +43,7 @@ describe Hyperion do
       let!(:expected_headers){{
           'Accept' => "application/vnd.indigobio-ascent.#{rd.type}-v#{rd.version}+#{rd.format}",
           'Content-Type' => 'application/json',
-          'Expect' => 'x'
+          'Expect' => nil
       }}
       it 'deserializes the response' do
         allow(Hyperion::Typho).to receive(:request).and_return(make_typho_response(200, '{"a":"b"}'))


### PR DESCRIPTION
I tested the change manually with wireshark.

Finished in 0.54586 seconds (files took 0.30804 seconds to load)
95 examples, 0 failures
