### PR TITLE
fake_route now works with multipart body

### DIFF
--- a/lib/hyperion/formats.rb
+++ b/lib/hyperion/formats.rb
@@ -31,6 +31,7 @@ class Hyperion
       case Formats.get_from(format)
       when :json; read_json(bytes)
       when :protobuf; bytes
+      when :form_data; bytes
       else; fail "Unsupported format: #{format}"
       end
     end

--- a/lib/hyperion/formats.rb
+++ b/lib/hyperion/formats.rb
@@ -31,7 +31,7 @@ class Hyperion
       case Formats.get_from(format)
       when :json; read_json(bytes)
       when :protobuf; bytes
-      when :form_data; bytes
+      when Multipart.format; bytes # currently only used for testing purposes
       else; fail "Unsupported format: #{format}"
       end
     end

--- a/lib/hyperion/headers.rb
+++ b/lib/hyperion/headers.rb
@@ -27,7 +27,8 @@ class Hyperion
     end
 
     ContentTypes = [[:json, 'application/json'],
-                    [:protobuf, 'application/x-protobuf']]
+                    [:protobuf, 'application/x-protobuf'],
+                    [:form_data, 'application/x-www-form-urlencoded']]
 
     def content_type_for(format)
       format = Hyperion::Formats.get_from(format)

--- a/lib/hyperion/headers.rb
+++ b/lib/hyperion/headers.rb
@@ -28,7 +28,7 @@ class Hyperion
 
     ContentTypes = [[:json, 'application/json'],
                     [:protobuf, 'application/x-protobuf'],
-                    [:form_data, 'application/x-www-form-urlencoded']]
+                    [Multipart.format, Multipart.content_type]]
 
     def content_type_for(format)
       format = Hyperion::Formats.get_from(format)
@@ -37,7 +37,7 @@ class Hyperion
     end
 
     def format_for(content_type)
-      ct = ContentTypes.detect{|x| x.last == content_type}
+      ct = ContentTypes.detect{|x| x.last == content_type.split(';')[0]}
       fail "Unsupported content type: #{content_type}" unless ct
       ct.first
     end

--- a/lib/hyperion/types/multipart.rb
+++ b/lib/hyperion/types/multipart.rb
@@ -1,1 +1,9 @@
-Multipart = Struct.new(:body)
+Multipart = Struct.new(:body) do
+  def self.format
+    :multipart
+  end
+
+  def self.content_type
+    'multipart/form-data'
+  end
+end

--- a/spec/lib/hyperion/formats_spec.rb
+++ b/spec/lib/hyperion/formats_spec.rb
@@ -82,6 +82,13 @@ class Hyperion
         it 'allows protobuf format but just passes it through' do
           expect(read('x', :protobuf)).to eql 'x'
         end
+        it 'allows multipart format data format but just passes it through' do
+          data = '--------------------------0bf18f00cf53ec0e' +
+              'Content-Disposition: form-data; name="file"; filename="test"' +
+              'Content-Type: application/octet-stream' +
+              '--------------------------0bf18f00cf53ec0e--'
+          expect(read(data, Multipart.format)).to eql data
+        end
       end
     end
   end

--- a/spec/lib/hyperion/headers_spec.rb
+++ b/spec/lib/hyperion/headers_spec.rb
@@ -51,6 +51,7 @@ class Hyperion
       it 'returns the format for the given content type' do
         expect(format_for('application/json')).to eql :json
         expect(format_for('application/x-protobuf')).to eql :protobuf
+        expect(format_for('multipart/form-data; boundary=------------------------2b463b63688b28fa')).to eql Multipart.format
       end
       it 'raises an error if the content type is unknown' do
         expect{format_for('aaa/bbb')}.to raise_error

--- a/spec/lib/hyperion_test/fake_route_spec.rb
+++ b/spec/lib/hyperion_test/fake_route_spec.rb
@@ -1,0 +1,24 @@
+require 'rspec'
+require 'hyperion/requestor'
+require 'hyperion_test'
+
+describe 'fake_route' do
+  include Hyperion::Requestor
+
+  context 'for multipart form data as a part of the body' do
+    let(:uri) { File.join('http://test.com', 'convert') }
+    let(:response_descriptor) { ResponseDescriptor.new('converted_sample', 1, :json) }
+    let(:route) { RestRoute.new(:post, uri, response_descriptor) }
+    let(:response) { {'x' => 1} }
+
+    it 'it fakes the given response' do
+      fake_route(route, JSON.dump(response))
+      expect(make_request(route)).to eql response
+    end
+
+    def make_request(route)
+      body = Multipart.new(file: File.open(File.expand_path('spec/fixtures/test'), 'r'))
+      request(route, body: body)
+    end
+  end
+end


### PR DESCRIPTION
Example spec that shows this failing before and fixed after: 

``` ruby
require 'rspec'
require 'hyperion/requestor'
require 'hyperion_test'

describe 'My behaviour' do
  include Hyperion::Requestor

  context 'convert' do
    let(:uri) { File.join('http://test.com', 'convert') }
    let(:response_descriptor) { ResponseDescriptor.new('converted_sample', 1, :json) }
    let(:route) { RestRoute.new(:post, uri, response_descriptor) }
    let(:zip_file_path) { 'path/to/zip/file' }

    context 'on a failed convert' do
      it 'raises an exception' do
        fake_route(route, error_response)
        expect{make_request}.to raise_error 'Failed to convert'
      end
    end
  end

  def make_request
    body = Multipart.new(file: 'path/to/file')
    handlers = {
        400 => proc { raise 'Failed to convert' }
    }
    request(route, body: body, also_handle: handlers)
  end

  def error_response
    response = ClientErrorResponse.new('Failure', [], ClientErrorCode::UNKNOWN)
    [400, {}, response.as_json]
  end
end
```
