### PR TITLE
Eliminate "callcc is obsolete" warnings

### DIFF
--- a/hyperion_http.gemspec
+++ b/hyperion_http.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'immutable_struct', '~> 1.1'
   spec.add_runtime_dependency 'oj', '~> 2.12'
   spec.add_runtime_dependency 'typhoeus', '~> 0.7'
-  spec.add_runtime_dependency 'mimic', '~> 0.4.3'
+  spec.add_runtime_dependency 'mimic', '0.4.3' # pin because 0.4.4 breaks tests
   spec.add_runtime_dependency 'logatron'
 end

--- a/lib/hyperion.rb
+++ b/lib/hyperion.rb
@@ -2,7 +2,6 @@
 require 'immutable_struct'
 require 'typhoeus'
 require 'oj'
-require 'continuation'
 require 'abstractivator/proc_ext'
 require 'abstractivator/enumerable_ext'
 require 'active_support/core_ext/object/blank'

--- a/lib/hyperion/aux/util.rb
+++ b/lib/hyperion/aux/util.rb
@@ -14,5 +14,28 @@ class Hyperion
       pred ||= proc { |x| x.is_a?(expected_type) }
       pred.call(value) or fail BugError, "You passed me #{value.inspect}, which is not #{what}"
     end
+
+    # reimplement callcc because ruby has deprecated it
+    def self.callcc()
+      in_scope = true
+      cont = proc do |retval|
+        unless in_scope
+          raise "Cannot invoke this continuation. Control has left this continuation's scope."
+        end
+        raise CallCcError.new(retval)
+      end
+      yield(cont)
+    rescue CallCcError => e
+      e.retval
+    ensure
+      in_scope = false
+    end
+
+    class CallCcError < RuntimeError
+      attr_accessor :retval
+      def initialize(retval)
+        @retval = retval
+      end
+    end
   end
 end

--- a/lib/hyperion/aux/version.rb
+++ b/lib/hyperion/aux/version.rb
@@ -1,3 +1,3 @@
 class Hyperion
-  VERSION = '0.1.7'
+  VERSION = '0.1.8'
 end

--- a/lib/hyperion/hyperion.rb
+++ b/lib/hyperion/hyperion.rb
@@ -60,7 +60,7 @@ class Hyperion
     result_maker = ResultMaker.new(route)
     if dispatch
       # callcc allows control to "jump" back here when the first predicate matches
-      callcc do |cont|
+      Util.callcc do |cont|
         dispatch.call(result_maker.make(typho_result, cont))
       end
     else

--- a/lib/hyperion_test/fake_server.rb
+++ b/lib/hyperion_test/fake_server.rb
@@ -3,6 +3,7 @@ require 'hyperion/aux/hash_ext'
 require 'hyperion_test/fake_server/dispatcher'
 require 'hyperion_test/fake_server/types'
 require 'hyperion_test/fake_server/config'
+require 'thin'
 
 class Hyperion
   class FakeServer
@@ -38,6 +39,7 @@ class Hyperion
         Mimic.cleanup!
         Mimic::Server.instance.instance_variable_get(:@thread).join
       end
+      Thin::Logging.silent = true # Thin always logs to STDOUT unless you quiet it
       Mimic.mimic(port: @port) do
         # this block executes in a strange context, which is why we
         # have to close over server and dispatcher

--- a/lib/hyperion_test/fake_server.rb
+++ b/lib/hyperion_test/fake_server.rb
@@ -3,7 +3,6 @@ require 'hyperion/aux/hash_ext'
 require 'hyperion_test/fake_server/dispatcher'
 require 'hyperion_test/fake_server/types'
 require 'hyperion_test/fake_server/config'
-require 'thin'
 
 class Hyperion
   class FakeServer
@@ -39,7 +38,6 @@ class Hyperion
         Mimic.cleanup!
         Mimic::Server.instance.instance_variable_get(:@thread).join
       end
-      Thin::Logging.silent = true # Thin always logs to STDOUT unless you quiet it
       Mimic.mimic(port: @port) do
         # this block executes in a strange context, which is why we
         # have to close over server and dispatcher

--- a/spec/lib/hyperion/aux/util_spec.rb
+++ b/spec/lib/hyperion/aux/util_spec.rb
@@ -25,5 +25,21 @@ class Hyperion
       end
     end
 
+    describe '::callcc' do
+      it 'returns the value of the block if the continuation is not invoked' do
+        v = Util.callcc { |_ret| 42 }
+        expect(v).to eql 42
+      end
+      it 'returns the argument if the continuation is invoked' do
+        v = Util.callcc { |ret| ret.call(99); 42 }
+        expect(v).to eql 99
+      end
+      it 'raises an error if the continuation is invoked outside of the block' do
+        cont = nil
+        Util.callcc { |ret| cont = ret }
+        expect { cont.call(99) }.to raise_error /continuation/
+      end
+    end
+
   end
 end

--- a/spec/lib/hyperion/headers_spec.rb
+++ b/spec/lib/hyperion/headers_spec.rb
@@ -54,7 +54,7 @@ class Hyperion
         expect(format_for('multipart/form-data; boundary=------------------------2b463b63688b28fa')).to eql Multipart.format
       end
       it 'raises an error if the content type is unknown' do
-        expect{format_for('aaa/bbb')}.to raise_error
+        expect{format_for('aaa/bbb')}.to raise_error /Unsupported content type/
       end
     end
 

--- a/spec/lib/hyperion/logger_spec.rb
+++ b/spec/lib/hyperion/logger_spec.rb
@@ -134,11 +134,12 @@ describe Hyperion::Logger do
   end
 
   def with_stdout(io)
+    prev_logger = Logatron.configuration.logger
     set_log_io(io)
     begin
       yield
     ensure
-      set_log_io($stdout)
+      Logatron.configuration.logger = prev_logger
     end
   end
 

--- a/spec/support/core_helpers.rb
+++ b/spec/support/core_helpers.rb
@@ -7,7 +7,7 @@ RSpec.configure do |config|
 end
 
 Logatron.configure do |c|
-  c.logger = Logger.new($stdout)
+  c.logger = Logger.new(ENV['VERBOSE'] == 'true' ? $stdout : '/dev/null')
   c.level = Logatron::DEBUG
   c.transformer = proc {|x| x[:body]}
 end


### PR DESCRIPTION
Hyperion uses `Kernel#callcc`, which is now deprecated. This means that every project that requires hyperion prints an annoying message.

callcc is a general purpose control construct. Ruby has a crippled version that can actually be implemented with exceptions. So I did that to eliminate the warnings.
