### PR TITLE
Eliminate "callcc is obsolete" warnings

### DIFF
--- a/lib/hyperion.rb
+++ b/lib/hyperion.rb
@@ -2,7 +2,6 @@
 require 'immutable_struct'
 require 'typhoeus'
 require 'oj'
-require 'continuation'
 require 'abstractivator/proc_ext'
 require 'abstractivator/enumerable_ext'
 require 'active_support/core_ext/object/blank'

--- a/lib/hyperion/aux/util.rb
+++ b/lib/hyperion/aux/util.rb
@@ -14,5 +14,28 @@ class Hyperion
       pred ||= proc { |x| x.is_a?(expected_type) }
       pred.call(value) or fail BugError, "You passed me #{value.inspect}, which is not #{what}"
     end
+
+    # reimplement callcc because ruby has deprecated it
+    def self.callcc()
+      in_scope = true
+      cont = proc do |retval|
+        unless in_scope
+          raise "Cannot invoke this continuation. Control has left this continuation's scope."
+        end
+        raise CallCcError.new(retval)
+      end
+      yield(cont)
+    rescue CallCcError => e
+      e.retval
+    ensure
+      in_scope = false
+    end
+
+    class CallCcError < RuntimeError
+      attr_accessor :retval
+      def initialize(retval)
+        @retval = retval
+      end
+    end
   end
 end

--- a/lib/hyperion/hyperion.rb
+++ b/lib/hyperion/hyperion.rb
@@ -60,7 +60,7 @@ class Hyperion
     result_maker = ResultMaker.new(route)
     if dispatch
       # callcc allows control to "jump" back here when the first predicate matches
-      callcc do |cont|
+      Util.callcc do |cont|
         dispatch.call(result_maker.make(typho_result, cont))
       end
     else

--- a/spec/lib/hyperion/aux/util_spec.rb
+++ b/spec/lib/hyperion/aux/util_spec.rb
@@ -3,7 +3,6 @@ require 'hyperion/aux/util'
 
 class Hyperion
   describe Util do
-
     describe '::nil_if_error' do
       it 'catches StandardErrors in the block' do
         expect(Util.nil_if_error { raise 'oops' }).to be_nil
@@ -25,5 +24,20 @@ class Hyperion
       end
     end
 
+    describe '::callcc' do
+      it 'returns the value of the block if the continuation is not invoked' do
+        v = Util.callcc { |_ret| 42 }
+        expect(v).to eql 42
+      end
+      it 'returns the argument if the continuation is invoked' do
+        v = Util.callcc { |ret| ret.call(99); 42 }
+        expect(v).to eql 99
+      end
+      it 'raises an error if the continuation is invoked outside of the block' do
+        cont = nil
+        Util.callcc { |ret| cont = ret }
+        expect { cont.call(99) }.to raise_error /continuation/
+      end
+    end
   end
 end


### PR DESCRIPTION
Hyperion uses `Kernel#callcc`, which is now deprecated. This means that every project that requires hyperion prints an annoying message.

callcc is a general purpose control construct. Ruby has a crippled version of callcc that can actually be implemented with exceptions. So I did that to eliminate the warnings.
